### PR TITLE
Deprecate old uses of createTempImageFileAndPersistUri and use DefaultContentFileProvider

### DIFF
--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
@@ -12,6 +12,8 @@ import com.android.camera.CropImageIntentBuilder;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * Created by Miguel Gaeta on 2/10/16.
@@ -61,19 +63,31 @@ public class MediaPicker {
      * Start the camera application correctly.
      *
      * @param provider Source {@link Provider}.
-     *
      * @param result The camera open action can fail so capture the result.
+     *
+     * @deprecated Implement your own {@link ContentFileProvider} and use
+     *      {@link #startForCamera(Provider, ContentFileProvider, BaseOnError)}.
+     *      For devices 24+ you must use a {@link android.support.v4.content.FileProvider} content URI.
+     *
+     * @see #startForCamera(Provider, ContentFileProvider, BaseOnError)
      */
     public static void startForCamera(final Provider provider, final OnError result) {
-
         try {
             final Uri captureFileURI = createTempImageFileAndPersistUri(provider.getContext());
+
             startForCamera(provider, captureFileURI, result);
         } catch (IOException e) {
             result.onError(e);
         }
     }
 
+    /**
+     * Start the camera application.
+     *
+     * @param provider Source {@link Provider}.
+     * @param fileProvider provides the necessary file for the camera to save into
+     * @param result The camera open action can fail so capture the result.
+     */
     public static void startForCamera(final Provider provider, final ContentFileProvider fileProvider, final BaseOnError result) {
         Uri captureFileURI = null;
         try{
@@ -86,11 +100,6 @@ public class MediaPicker {
         }
 
         startForCamera(provider, captureFileURI, result);
-    }
-
-    public interface ContentFileProvider {
-        File createFile() throws IOException;
-        Uri toUri(File file);
     }
 
     public static void startForCamera(final Provider provider, final Uri captureFileURI, final OnError result) {
@@ -313,22 +322,34 @@ public class MediaPicker {
     }
 
     /**
+     * @deprecated Implement your own {@link ContentFileProvider} and use
+     *      {@link #createTempImageFileAndPersistUri(Context, ContentFileProvider)}.
+     *      For devices 24+ you must use a {@link android.support.v4.content.FileProvider} content URI.
+     *
+     * @see #createTempImageFileAndPersistUri(Context, ContentFileProvider)
+     */
+    private static Uri createTempImageFileAndPersistUri(final Context context) throws IOException {
+        return createTempImageFileAndPersistUri(context, new MediaPickerFile.DefaultContentFileProvider());
+    }
+
+    /**
      * Create a temporary image file and persist it for later retrieval.  We use shared
      * preferences here in the case that we lose our current
      * instance by the time the activity returns a result.
      *
      * @param context Source {@link Context}.
+     * @param fileProvider provides the necessary file for the camera to save into
      *
      * @return Uri of the created file.
      *
      * @throws IOException
      */
-    private static Uri createTempImageFileAndPersistUri(final Context context) throws IOException {
+    private static Uri createTempImageFileAndPersistUri(final Context context, ContentFileProvider fileProvider) throws IOException {
 
-        final Uri captureFileURI = Uri.fromFile(MediaPickerFile.createWithSuffix(".jpg"));
+        final File file = fileProvider.createFile();
+        final Uri captureFileURI = fileProvider.toUri(file);
 
         persistUri(context, captureFileURI.toString());
-
         return captureFileURI;
     }
 
@@ -447,6 +468,25 @@ public class MediaPicker {
 
             }
         }
+    }
+
+    /**
+     * Knows how to create a file to be used by the MediaPicker to save images.
+     *
+     * For API 24+ you must use a {@link android.support.v4.content.FileProvider} content URI.
+     */
+    public interface ContentFileProvider {
+        File createFile() throws IOException;
+
+        /**
+         * Converts the File to a Uri.
+         *
+         * @param file {@link File} to be sent to the media source to write data.
+         * @return {@link Uri} representation of the <code>file</code>. For API 24+ this must be a {@link Uri}
+         *      provided by the {@link android.support.v4.content.FileProvider}
+         *
+         */
+        Uri toUri(File file);
     }
 
     /**

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPickerFile.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPickerFile.java
@@ -94,4 +94,20 @@ public class MediaPickerFile {
 
         return create("media_picker", UUID.randomUUID().toString(), suffix);
     }
+
+    /**
+     * Provides a simple default implementation to create a file for the {@link  MediaPicker}.
+     */
+    public static class DefaultContentFileProvider implements MediaPicker.ContentFileProvider {
+        @Override
+        public File createFile() throws IOException {
+            return MediaPickerFile.createWithSuffix(".jpg");
+        }
+
+        @Override
+        public Uri toUri(final File file) {
+            return Uri.fromFile(file);
+        }
+    }
+
 }


### PR DESCRIPTION
- clients should move towards implementing a `ContentFileProvider` as it offers more flexibilty.
- for support above API 24+, the file URI needs to be supplied via a `FileProvider` so this is required