### PR TITLE
Opt/mime types

### DIFF
--- a/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
+++ b/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
@@ -85,9 +85,9 @@ public class AppActivity extends AppCompatActivity implements MediaPicker.Provid
             }
 
             @Override
-            public void onSuccess(File mediaFile, MediaPickerRequest request) {
+            public void onSuccess(final File mediaFile, final String mimeType, MediaPickerRequest request) {
 
-                Log.e("MediaPicker", "Got file result: " + mediaFile + " for code: " + request);
+                Log.e("MediaPicker", "Got file result: '" + mediaFile + "', with mime type: '" + mimeType + "', for code: '" + request + "'.");
 
                 if (request != MediaPickerRequest.REQUEST_CROP) {
 

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
@@ -12,16 +12,14 @@ import com.android.camera.CropImageIntentBuilder;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * Created by Miguel Gaeta on 2/10/16.
  */
-@SuppressWarnings({"UnusedDeclaration", "DefaultFileTemplate"})
+@SuppressWarnings({"UnusedDeclaration", "DefaultFileTemplate", "JavadocReference"})
 public class MediaPicker {
 
-    static final String NAME = "media_picker";
+    private static final String NAME = "media_picker";
 
     /**
      * @see #openMediaChooser(Provider, String, OnError)
@@ -89,7 +87,7 @@ public class MediaPicker {
      * @param result The camera open action can fail so capture the result.
      */
     public static void startForCamera(final Provider provider, final ContentFileProvider fileProvider, final BaseOnError result) {
-        Uri captureFileURI = null;
+        Uri captureFileURI;
         try{
             File photoFile =  fileProvider.createFile();
             captureFileURI = fileProvider.toUri(photoFile);
@@ -102,6 +100,7 @@ public class MediaPicker {
         startForCamera(provider, captureFileURI, result);
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static void startForCamera(final Provider provider, final Uri captureFileURI, final OnError result) {
 
         try {
@@ -246,11 +245,12 @@ public class MediaPicker {
 
                 case Activity.RESULT_OK:
 
-                    final File file = MediaPickerUri.resolveToFile(context, handleActivityUriResult(context, request, data));
+                    final Uri uri = handleActivityUriResult(context, request, data);
+                    final File file = MediaPickerUri.resolveToFile(context, uri);
 
                     refreshSystemMediaScanDataBase(context, file);
 
-                    result.onSuccess(file, request);
+                    result.onSuccess(file, MimeType.getMimeType(context, uri), request);
 
                     break;
 
@@ -283,7 +283,7 @@ public class MediaPicker {
      *
      * @return File URI.
      *
-     * @throws IOException
+     * @throws IOException Error thrown when no result can be extracted.
      */
     private static Uri handleActivityUriResult(final Context context, final MediaPickerRequest request, final Intent data) throws IOException {
 
@@ -342,7 +342,7 @@ public class MediaPicker {
      *
      * @return Uri of the created file.
      *
-     * @throws IOException
+     * @throws IOException Throws if cannot be created or persisted.
      */
     private static Uri createTempImageFileAndPersistUri(final Context context, ContentFileProvider fileProvider) throws IOException {
 
@@ -350,6 +350,7 @@ public class MediaPicker {
         final Uri captureFileURI = fileProvider.toUri(file);
 
         persistUri(context, captureFileURI.toString());
+
         return captureFileURI;
     }
 
@@ -418,6 +419,7 @@ public class MediaPicker {
      * Refresh so file appears in associated
      * gallery and media explorer applications.
      */
+    @SuppressWarnings("WeakerAccess")
     public static void refreshSystemMediaScanDataBase(final Context context, final File file) {
         final Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
 
@@ -438,9 +440,7 @@ public class MediaPicker {
 
     public static abstract class BaseOnError implements OnError {
 
-        public void onFileCreationError(final Exception e) {
-            return;
-        }
+        public void onFileCreationError(final Exception e) { }
     }
 
     /**
@@ -449,25 +449,9 @@ public class MediaPicker {
      */
     public interface OnResult extends OnError {
 
-        void onSuccess(final File mediaFile, MediaPickerRequest request);
+        void onSuccess(final File mediaFile, final String mimeType, final MediaPickerRequest request);
 
         void onCancelled();
-
-        /**
-         * Most consumers only care about the success callback.
-         */
-        abstract class Default implements OnResult {
-
-            @Override
-            public void onCancelled() {
-
-            }
-
-            @Override
-            public void onError(IOException e) {
-
-            }
-        }
     }
 
     /**
@@ -475,6 +459,7 @@ public class MediaPicker {
      *
      * For API 24+ you must use a {@link android.support.v4.content.FileProvider} content URI.
      */
+    @SuppressWarnings("JavadocReference")
     public interface ContentFileProvider {
         File createFile() throws IOException;
 

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPickerUri.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPickerUri.java
@@ -189,15 +189,21 @@ public class MediaPickerUri {
             case AUTHORITY_DOWNLOADS_DOCUMENT: {
 
                 final Uri contentUri = Uri.parse("content://downloads/public_downloads");
-                final Uri contentUriAppended = ContentUris.withAppendedId(contentUri, Long.valueOf(documentId));
 
-                final String path = getDataColumn(context, contentUriAppended, null, null);
+                try {
+                    final Uri contentUriAppended = ContentUris.withAppendedId(contentUri, Long.valueOf(documentId));
 
-                if (path == null) {
-                    throw new IOException("Unable to find downloaded document path.");
+                    final String path = getDataColumn(context, contentUriAppended, null, null);
+
+                    if (path == null) {
+                        throw new IOException("Unable to find downloaded document path.");
+                    }
+
+                    return path;
+
+                } catch (NumberFormatException e) {
+                    throw new IOException("Unable to fetch document id.");
                 }
-
-                return path;
             }
             case AUTHORITY_MEDIA_DOCUMENT: {
 

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MimeType.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MimeType.java
@@ -17,6 +17,18 @@ public class MimeType {
     private static final MimeTypeMap MIME_TYPE_MAP = MimeTypeMap.getSingleton();
 
     /**
+     * Convenience method to determine if a given
+     * mime type is an image.
+     *
+     * @param mimeType Mime type string.
+     *
+     * @return True if image, false otherwise.
+     */
+    public boolean isImage(final String mimeType) {
+        return mimeType != null && mimeType.startsWith("image/");
+    }
+
+    /**
      * Get a best guess of the mime type associated with the target {@link Uri}.
      *
      * @param context Optional {@link Context} that checks for mime type from {@link ContentResolver}.

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MimeType.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MimeType.java
@@ -11,7 +11,7 @@ import android.webkit.MimeTypeMap;
  * extraction methods to heuristically determine a
  * best guess for the associated type.
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "WeakerAccess"})
 public class MimeType {
 
     private static final MimeTypeMap MIME_TYPE_MAP = MimeTypeMap.getSingleton();
@@ -24,7 +24,6 @@ public class MimeType {
      *
      * @return Discovered mime type or null.
      */
-    @SuppressWarnings("WeakerAccess")
     public static String getMimeType(final Context context, final Uri uri) {
         if (uri == null) {
             return null;

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MimeType.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MimeType.java
@@ -1,0 +1,96 @@
+package com.miguelgaeta.media_picker;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.net.Uri;
+import android.webkit.MimeTypeMap;
+
+/**
+ * Exposes methods for extracting mime type given a
+ * target url or uri.  Uses a combination of
+ * extraction methods to heuristically determine a
+ * best guess for the associated type.
+ */
+@SuppressWarnings("unused")
+public class MimeType {
+
+    private static final MimeTypeMap MIME_TYPE_MAP = MimeTypeMap.getSingleton();
+
+    /**
+     * Get a best guess of the mime type associated with the target {@link Uri}.
+     *
+     * @param context Optional {@link Context} that checks for mime type from {@link ContentResolver}.
+     * @param uri Target {@link Uri} to obtain mime type for.
+     *
+     * @return Discovered mime type or null.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static String getMimeType(final Context context, final Uri uri) {
+        if (uri == null) {
+            return null;
+        }
+
+        if (context != null) {
+            final String mimeType = getMimeTypeFromContentResolver(context.getContentResolver(), uri);
+
+            if (mimeType != null) {
+                return mimeType;
+            }
+        }
+
+        return getMimeTypeFromExtension(uri.toString());
+    }
+
+    /**
+     * @see #getMimeType(Context, Uri)
+     */
+    public static String getMimeType(final Context context, final String url) {
+        if (url == null) {
+            return null;
+        }
+
+        final Uri uri = Uri.parse(url);
+
+        return getMimeType(context, uri);
+    }
+
+    /**
+     * Uses {@link ContentResolver#getType(Uri)} to extract a mime type.
+     *
+     * @param contentResolver {@link ContentResolver}.
+     * @param uri {@link Uri}.
+     *
+     * @return Discovered mime type or null.
+     */
+    private static String getMimeTypeFromContentResolver(final ContentResolver contentResolver,
+                                                         final Uri uri) {
+        if (uri == null || uri.getScheme() == null || contentResolver == null) {
+            return null;
+        }
+
+        if (!uri.getScheme().equals(ContentResolver.SCHEME_CONTENT)) {
+            return null;
+        }
+
+        return contentResolver.getType(uri);
+    }
+
+    /**
+     * Uses {@link MimeTypeMap#getMimeTypeFromExtension(String)} to extract a mime type.
+     *
+     * @param url {@link Uri}.
+     *
+     * @return Discovered mime type or null.
+     */
+    private static String getMimeTypeFromExtension(final String url) {
+        String extension = MimeTypeMap.getFileExtensionFromUrl(url);
+
+        if (extension != null) {
+            extension = extension.toLowerCase();
+
+            return MIME_TYPE_MAP.getMimeTypeFromExtension(extension);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Adds a mime type utility class and updated the `onSuccess` contract to also return a best guess for the mime type of the chosen file.

Remove `Default` implementation of `OnResult` as it's is not unreasonable for consumers to provide a default error implementation.