### PR TITLE
Feature/file provider api

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,15 +15,5 @@
             </intent-filter>
         </activity>
 
-        <provider
-            android:name="android.support.v4.content.FileProvider"
-            android:authorities="com.miguelgaeta.android_media_picker.file-provider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths"/>
-        </provider>
-
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
 
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="com.miguelgaeta.android_media_picker.fileprovider"
+            android:authorities="com.miguelgaeta.android_media_picker.file-provider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
+++ b/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
@@ -12,14 +12,12 @@ import android.util.Log;
 
 import com.miguelgaeta.media_picker.MediaPicker;
 import com.miguelgaeta.media_picker.MediaPickerEncoder;
+import com.miguelgaeta.media_picker.MediaPickerFile;
 import com.miguelgaeta.media_picker.MediaPickerRequest;
 import com.tbruyelle.rxpermissions.RxPermissions;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
 
 @SuppressWarnings({"ConstantConditions", "CodeBlock2Expr"})
 public class AppActivity extends AppCompatActivity implements MediaPicker.Provider {
@@ -41,20 +39,10 @@ public class AppActivity extends AppCompatActivity implements MediaPicker.Provid
                 Log.e("MediaPicker", "Permission result: " + permission);
             });
 
-        findViewById(R.id.activity_open_camera_provider).setOnClickListener(v -> MediaPicker.startForCamera(
-                AppActivity.this,
-                new MyContentFileProvider(),
-                new MediaPicker.BaseOnError() {
-                    @Override
-                    public void onError(final IOException e) {
-                        Log.e("MediaPicker", "Start for camera error.", e);
-                    }
+        findViewById(R.id.activity_open_camera_provider).setOnClickListener(v -> MediaPicker.startForCamera(this, e -> {
 
-                    @Override
-                    public void onFileCreationError(final Exception e) {
-                        Log.e("MediaPicker", "Creating output file error.", e);
-                    }
-                }));
+            Log.e("MediaPicker", "Start for camera error.", e);
+        }));
 
         findViewById(R.id.activity_open_gallery).setOnClickListener(v -> MediaPicker.startForGallery(this, e -> {
 
@@ -127,22 +115,15 @@ public class AppActivity extends AppCompatActivity implements MediaPicker.Provid
         return this;
     }
 
-    private class MyContentFileProvider implements MediaPicker.ContentFileProvider {
-        @Override
-        public File createFile() throws IOException {
-            File imagePath = getExternalFilesDir("images");
+    @Override
+    public File createFile() throws IOException {
+        return MediaPickerFile.create(getFilesDir(), "images", ".jpg");
+    }
 
-            String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(new Date());
-            String imageFileName = "img_" + timeStamp;
-            return File.createTempFile(imageFileName, ".jpg", imagePath);
+    @Override
+    public Uri toUri(final File file) {
+        final String authority = BuildConfig.APPLICATION_ID + ".file-provider";
 
-        }
-
-        @Override
-        public Uri toUri(final File file) {
-            return FileProvider.getUriForFile(AppActivity.this,
-                    BuildConfig.APPLICATION_ID + ".fileprovider",
-                    file);
-        }
+        return FileProvider.getUriForFile(this, authority, file);
     }
 }

--- a/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
+++ b/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
@@ -3,16 +3,13 @@ package com.miguelgaeta.android_media_picker;
 import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
-import android.support.v4.content.FileProvider;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
 import com.miguelgaeta.media_picker.MediaPicker;
 import com.miguelgaeta.media_picker.MediaPickerEncoder;
-import com.miguelgaeta.media_picker.MediaPickerFile;
 import com.miguelgaeta.media_picker.MediaPickerRequest;
 import com.tbruyelle.rxpermissions.RxPermissions;
 
@@ -113,17 +110,5 @@ public class AppActivity extends AppCompatActivity implements MediaPicker.Provid
     @Override
     public Context getContext() {
         return this;
-    }
-
-    @Override
-    public File createFile() throws IOException {
-        return MediaPickerFile.create(getFilesDir(), "images", ".jpg");
-    }
-
-    @Override
-    public Uri toUri(final File file) {
-        final String authority = BuildConfig.APPLICATION_ID + ".file-provider";
-
-        return FileProvider.getUriForFile(this, authority, file);
     }
 }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,3 +1,3 @@
-<paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-files-path name="images" path="images/"/>
+<paths>
+    <files-path name="images" path="images/"/>
 </paths>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,3 +1,0 @@
-<paths>
-    <files-path name="images" path="images/"/>
-</paths>

--- a/media-picker/build.gradle
+++ b/media-picker/build.gradle
@@ -21,6 +21,9 @@ android {
 
 dependencies {
 
+    //noinspection GradleDynamicVersion
+    compile 'com.android.support:support-core-utils:25.+'
+
     // Crop images android library.
     compile 'me.villani.lorenzo.android:android-cropimage:1.1.2'
 }

--- a/media-picker/build.gradle
+++ b/media-picker/build.gradle
@@ -21,11 +21,11 @@ android {
 
 dependencies {
 
-    //noinspection GradleDynamicVersion
+    //noinspection GradleDynamicVersion || File provider compatibility.
     compile 'com.android.support:support-core-utils:25.+'
 
-    // Crop images android library.
-    compile 'me.villani.lorenzo.android:android-cropimage:1.1.2'
+    //noinspection GradleDynamicVersion || File cropping utility.
+    compile 'me.villani.lorenzo.android:android-cropimage:1.+'
 }
 
 apply from: '../build.release-aar.gradle'

--- a/media-picker/src/main/AndroidManifest.xml
+++ b/media-picker/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="com.miguelgaeta.media_picker"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.miguelgaeta.media_picker" xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- User for the camera itself. -->
     <uses-permission android:name="android.permission.CAMERA" />
@@ -13,6 +12,16 @@
 
         <!-- Used for cropping images -->
         <activity android:name="com.android.camera.CropImage"/>
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.file-provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths"/>
+        </provider>
 
     </application>
 

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
@@ -90,7 +90,7 @@ public class MediaPicker {
 
             startFor(provider, intent, MediaPickerRequest.REQUEST_GALLERY.getCode());
 
-        } catch (IOException e) {
+        } catch (final IOException e) {
 
             result.onError(e);
         }
@@ -113,7 +113,7 @@ public class MediaPicker {
 
             startFor(provider, intent, MediaPickerRequest.REQUEST_DOCUMENTS.getCode());
 
-        } catch (IOException e) {
+        } catch (final IOException e) {
 
             result.onError(e);
         }
@@ -151,7 +151,7 @@ public class MediaPicker {
 
             startFor(provider, intentBuilder.getIntent(provider.getContext()), MediaPickerRequest.REQUEST_CROP.getCode());
 
-        } catch (IOException e) {
+        } catch (final IOException e) {
 
             result.onError(e);
         }
@@ -173,7 +173,7 @@ public class MediaPicker {
                 provider.startActivityForResult(intent, requestCode);
             }
 
-        } catch (ActivityNotFoundException e) {
+        } catch (final ActivityNotFoundException e) {
 
             throw new IOException("No application available for media picker.");
         }
@@ -225,7 +225,7 @@ public class MediaPicker {
                     throw new IOException("Bad activity result code: " + resultCode + ", for request code: " + requestCode);
             }
 
-        } catch (IOException e) {
+        } catch (final IOException e) {
 
             result.onError(e);
         }

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
@@ -46,7 +46,7 @@ public class MediaPicker {
 
             startFor(provider, intent, MediaPickerRequest.REQUEST_CHOOSER.getCode());
 
-        } catch (IOException e) {
+        } catch (final IOException e) {
 
             result.onError(e);
         }
@@ -69,8 +69,9 @@ public class MediaPicker {
 
             startFor(provider, intent, MediaPickerRequest.REQUEST_CAPTURE.getCode());
 
-        } catch (final Exception e) {
-            result.onError(new IOException("Unable to create temporary file.", e));
+        } catch (final IOException e) {
+
+            result.onError(e);
         }
     }
 

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPickerFile.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPickerFile.java
@@ -1,15 +1,15 @@
 package com.miguelgaeta.media_picker;
 
+import android.content.Context;
 import android.graphics.BitmapFactory;
 import android.graphics.Rect;
 import android.net.Uri;
-import android.os.Environment;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
-@SuppressWarnings("UnusedDeclaration")
+@SuppressWarnings({"UnusedDeclaration", "WeakerAccess"})
 public class MediaPickerFile {
 
     public static Rect getImageDimensions(final File file) {
@@ -31,21 +31,23 @@ public class MediaPickerFile {
     /**
      * Create a file in the devices external storage.
      *
-     * @param directory Target directory.
+     * @param root Root directory, typically invoked from {@link Context#getFilesDir()}.
+     * @param directory Target directory within root.
      * @param name Target file name.
      * @param suffix Target file suffix.
      *
      * @return Created file.
      *
-     * @throws IOException
+     * @throws IOException Throws when unable to create a file.
      */
-    public static File create(final String directory, final String name, final String suffix) throws IOException {
+    public static File create(final File root, final String directory, final String suffix, final String name) throws IOException {
 
-        final File dir = new File(Environment.getExternalStorageDirectory() + File.separator + directory);
+        final File path = new File(root, directory);
+        final File file = new File(path + File.separator + name + suffix);
 
-        if (!dir.exists()) {
+        if (!path.exists()) {
 
-            boolean result = dir.mkdirs();
+            boolean result = path.mkdirs();
 
             if (!result) {
 
@@ -53,61 +55,38 @@ public class MediaPickerFile {
             }
         }
 
-        final File file = File.createTempFile(name, suffix, dir);
-
         if (!file.exists()) {
+            final boolean created = file.createNewFile();
 
-            throw new IOException("Unable to create temporary file, does not exist.");
+            if (!created) {
+                throw new IOException("Unable to create temporary file, does not exist.");
+            }
         }
 
         return file;
     }
 
     /**
-     * @see #create(String, String, String)
+     * @see #create(File, String, String, String)
      */
-    public static File create(final String directory, final String name) throws IOException {
+    public static File create(final File root, final String directory, final String suffix) throws IOException {
 
-        return create(directory, name, null);
+        return create(root, directory, suffix, UUID.randomUUID().toString());
     }
 
     /**
-     * @see #create(String, String)
+     * @see #create(File, String, String)
      */
-    public static File create(final String directory) throws IOException {
+    public static File create(final File root, final String directory) throws IOException {
 
-        return create(directory, UUID.randomUUID().toString());
+        return create(root, directory, ".tmp");
     }
 
     /**
-     * @see #create(String)
+     * @see #create(File, String)
      */
-    public static File create() throws IOException {
+    public static File create(final File root) throws IOException {
 
-        return create("media_picker");
+        return create(root, "temp");
     }
-
-    /**
-     * @see #create(String, String, String)
-     */
-    public static File createWithSuffix(final String suffix) throws IOException {
-
-        return create("media_picker", UUID.randomUUID().toString(), suffix);
-    }
-
-    /**
-     * Provides a simple default implementation to create a file for the {@link  MediaPicker}.
-     */
-    public static class DefaultContentFileProvider implements MediaPicker.ContentFileProvider {
-        @Override
-        public File createFile() throws IOException {
-            return MediaPickerFile.createWithSuffix(".jpg");
-        }
-
-        @Override
-        public Uri toUri(final File file) {
-            return Uri.fromFile(file);
-        }
-    }
-
 }

--- a/media-picker/src/main/res/xml/file_paths.xml
+++ b/media-picker/src/main/res/xml/file_paths.xml
@@ -1,0 +1,3 @@
+<paths>
+    <files-path name="file-picker" path="files/"/>
+</paths>


### PR DESCRIPTION
Internalizes the file provider API recommended to be used and provided by the Android support library.

The library consumers no longer need to worry about defining their own providers and the semantics of creating files and converting them to URI's.

The boiler plate needed to build temporary images files to drive the camera is now implemented internally using an {applicationId} manifest merger and `context.getPackage()` for resolving the correct authority.

