### PR TITLE
Fix choosing media from older API versions.

### DIFF
--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPickerChooser.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPickerChooser.java
@@ -80,7 +80,11 @@ class MediaPickerChooser {
                                                               final @NonNull Uri captureFileURI,
                                                               final @NonNull String mimeType) {
 
-        final Intent typeCamera = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
+        final Intent typeCamera = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE)
+            .putExtra(MediaStore.EXTRA_OUTPUT, captureFileURI)
+            .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
         final Intent typeGallery = MediaPicker.getIntent(Intent.ACTION_PICK, mimeType);
         final Intent typeDocuments = MediaPicker.getIntent(Intent.ACTION_GET_CONTENT, mimeType);
 


### PR DESCRIPTION
Explicitly grant write permissions to provided file URI when a camera could be access or a file cropped.

This is required for older android API versions when using the `FileProvider` API.