### PR TITLE
Rename request type enum for clarity.

### DIFF
--- a/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
+++ b/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
@@ -11,7 +11,7 @@ import android.widget.Toast;
 
 import com.miguelgaeta.media_picker.MediaPicker;
 import com.miguelgaeta.media_picker.Encoder;
-import com.miguelgaeta.media_picker.MediaPickerRequest;
+import com.miguelgaeta.media_picker.RequestType;
 import com.miguelgaeta.media_picker.MimeType;
 import com.tbruyelle.rxpermissions.RxPermissions;
 
@@ -81,11 +81,11 @@ public class AppActivity extends AppCompatActivity implements MediaPicker.Provid
             }
 
             @Override
-            public void onSuccess(final File file, final String mimeType, MediaPickerRequest request) {
+            public void onSuccess(final File file, final String mimeType, RequestType request) {
 
                 Log.e("MediaPicker", "Got file result: '" + file + "', with mime type: '" + mimeType + "', for code: '" + request + "'.");
 
-                if (request == MediaPickerRequest.REQUEST_GALLERY) {
+                if (request == RequestType.GALLERY) {
                     try {
                         final String encoded = Encoder.getDataUrl(mimeType, file);
 
@@ -95,7 +95,7 @@ public class AppActivity extends AppCompatActivity implements MediaPicker.Provid
                     }
                 }
 
-                if (request != MediaPickerRequest.REQUEST_CROP && MimeType.isImage(mimeType)) {
+                if (request != RequestType.CROP && MimeType.isImage(mimeType)) {
 
                     final int paramColor = ContextCompat.getColor(AppActivity.this, android.R.color.black);
                     final int paramWidth = 128;

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-alpha2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
@@ -10,7 +10,6 @@ import android.os.Build;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.v4.content.FileProvider;
-import android.util.Log;
 
 import com.android.camera.CropImageIntentBuilder;
 
@@ -38,7 +37,7 @@ public class MediaPicker {
 
             final Intent intent = MediaPickerChooser.getMediaChooserIntent(provider.getContext().getPackageManager(), title, captureFileURI, mimeType);
 
-            startFor(provider, intent, MediaPickerRequest.REQUEST_CHOOSER.getCode());
+            startFor(provider, intent, RequestType.CHOOSER.getCode());
 
         } catch (final IOException e) {
 
@@ -68,7 +67,7 @@ public class MediaPicker {
                 .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
                 .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
-            startFor(provider, intent, MediaPickerRequest.REQUEST_CAPTURE.getCode());
+            startFor(provider, intent, RequestType.CAMERA.getCode());
 
         } catch (final IOException e) {
 
@@ -88,7 +87,7 @@ public class MediaPicker {
 
             final Intent intent = getIntent(Intent.ACTION_PICK, mimeType);
 
-            startFor(provider, intent, MediaPickerRequest.REQUEST_GALLERY.getCode());
+            startFor(provider, intent, RequestType.GALLERY.getCode());
 
         } catch (final IOException e) {
 
@@ -116,7 +115,7 @@ public class MediaPicker {
 
             final Intent intent = getIntent(Intent.ACTION_GET_CONTENT, mimeType);
 
-            startFor(provider, intent, MediaPickerRequest.REQUEST_DOCUMENTS.getCode());
+            startFor(provider, intent, RequestType.DOCUMENTS.getCode());
 
         } catch (final IOException e) {
 
@@ -161,7 +160,7 @@ public class MediaPicker {
             intentBuilder.setOutlineColor(colorInt);
             intentBuilder.setScaleUpIfNeeded(true);
 
-            startFor(provider, intentBuilder.getIntent(provider.getContext()), MediaPickerRequest.REQUEST_CROP.getCode());
+            startFor(provider, intentBuilder.getIntent(provider.getContext()), RequestType.CROP.getCode());
 
         } catch (final IOException e) {
 
@@ -202,7 +201,7 @@ public class MediaPicker {
      */
     public static void handleActivityResult(final Context context, final int requestCode, final int resultCode, final Intent data, final OnResult onError) {
 
-        final MediaPickerRequest request = MediaPickerRequest.create(requestCode);
+        final RequestType request = RequestType.create(requestCode);
 
         if (request == null) {
 
@@ -255,16 +254,16 @@ public class MediaPicker {
      *
      * @throws IOException Error thrown when no result can be extracted.
      */
-    private static Uri handleActivityUriResult(final Context context, final MediaPickerRequest request, final Intent data) throws IOException {
+    private static Uri handleActivityUriResult(final Context context, final RequestType request, final Intent data) throws IOException {
 
         switch (request) {
 
-            case REQUEST_CAPTURE:
-            case REQUEST_CROP:
+            case CAMERA:
+            case CROP:
 
                 return getCaptureFileUriAndClear(context);
 
-            case REQUEST_CHOOSER:
+            case CHOOSER:
 
                 if (data != null && data.getData() != null) {
 
@@ -275,8 +274,8 @@ public class MediaPicker {
 
                 return getCaptureFileUriAndClear(context);
 
-            case REQUEST_DOCUMENTS:
-            case REQUEST_GALLERY:
+            case DOCUMENTS:
+            case GALLERY:
 
                 deleteCaptureFileUri(context);
 
@@ -430,7 +429,7 @@ public class MediaPicker {
      */
     public interface OnResult extends OnError {
 
-        void onSuccess(final File mediaFile, final String mimeType, final MediaPickerRequest request);
+        void onSuccess(final File mediaFile, final String mimeType, final RequestType request);
 
         void onCancelled();
     }

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/RequestType.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/RequestType.java
@@ -3,13 +3,13 @@ package com.miguelgaeta.media_picker;
 /**
  * Created by Miguel Gaeta on 2/11/16.
  */
-public enum MediaPickerRequest {
+public enum RequestType {
 
-    REQUEST_CAPTURE,
-    REQUEST_GALLERY,
-    REQUEST_DOCUMENTS,
-    REQUEST_CROP,
-    REQUEST_CHOOSER;
+    CAMERA,
+    GALLERY,
+    DOCUMENTS,
+    CROP,
+    CHOOSER;
 
     /**
      * Internally get the associated request code to used in
@@ -18,27 +18,16 @@ public enum MediaPickerRequest {
      * @return Unique request code for each operation.
      */
     int getCode() {
-
         switch (this) {
-
-            case REQUEST_CAPTURE:
-
+            case CAMERA:
                 return 777;
-
-            case REQUEST_GALLERY:
-
+            case GALLERY:
                 return 778;
-
-            case REQUEST_DOCUMENTS:
-
+            case DOCUMENTS:
                 return 779;
-
-            case REQUEST_CROP:
-
+            case CROP:
                 return 800;
-
-            case REQUEST_CHOOSER:
-
+            case CHOOSER:
                 return 801;
         }
 
@@ -53,29 +42,18 @@ public enum MediaPickerRequest {
      *
      * @return Request enum.
      */
-    static MediaPickerRequest create(int code) {
-
+    static RequestType create(int code) {
         switch (code) {
-
             case 777:
-
-                return REQUEST_CAPTURE;
-
+                return CAMERA;
             case 778:
-
-                return REQUEST_GALLERY;
-
+                return GALLERY;
             case 779:
-
-                return REQUEST_DOCUMENTS;
-
+                return DOCUMENTS;
             case 800:
-
-                return REQUEST_CROP;
-
+                return CROP;
             case 801:
-
-                return REQUEST_CHOOSER;
+                return CHOOSER;
         }
 
         return null;


### PR DESCRIPTION
Rename the enum to make more semantic sense, the new name is:

`RequestType` and each value removed the `REQUEST_` prefix.