### PR TITLE
Bug/delete temp file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1 - 2017-02-23
+
+-- Don't delete temporary camera URI since it is not created.
+
 ## 1.5.0 - 2017-02-23
 
 - Delegate file provider to consuming application.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ compile 'com.miguelgaeta.android-media-picker:media-picker:1.5.0'
 
 ### Usage
 
-First implement the MediaPicker.Provider interface in your Activities or Fragments.  Then open media chooser - presents the user with a chooser showing all matching activities for picking media:
+First implement the `MediaPicker.Provider` interface in your Activities or Fragments.  Then open media chooser - presents the user with a chooser showing all matching activities for picking media:
 
 ```java
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A utility library that allows a user to easily take a picture from the gallery, 
 
 ```groovy
 
-compile 'com.miguelgaeta.android-media-picker:media-picker:1.5.0'
+compile 'com.miguelgaeta.android-media-picker:media-picker:1.5.1'
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ allprojects {
 
 ```
 
-For operations that require it, `WRITE_EXTERNAL_STORAGE` permission is added to the merged [Manifest](http://developer.android.com/guide/topics/manifest/manifest-intro.html).  You do not need to add this permission into your own manifest.
+For operations that require it, `WRITE_EXTERNAL_STORAGE`, `READ_EXTERNAL_STORAGE` permissions are added to the merged [Manifest](http://developer.android.com/guide/topics/manifest/manifest-intro.html).  You do not need to add this permission into your own manifest.
 
 ### License
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ android {
 dependencies {
 
     // Support libraries.
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:25.2.0'
 
     // Rx Java permissions handler.
     compile 'com.tbruyelle.rxpermissions:rxpermissions:0.5.2@aar'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,5 +15,14 @@
             </intent-filter>
         </activity>
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.file-provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths"/>
+        </provider>
     </application>
 </manifest>

--- a/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
+++ b/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
@@ -1,22 +1,26 @@
 package com.miguelgaeta.android_media_picker;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Environment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.widget.Toast;
 
-import com.miguelgaeta.media_picker.MediaPicker;
 import com.miguelgaeta.media_picker.Encoder;
-import com.miguelgaeta.media_picker.RequestType;
+import com.miguelgaeta.media_picker.MediaPicker;
 import com.miguelgaeta.media_picker.MimeType;
+import com.miguelgaeta.media_picker.RequestType;
 import com.tbruyelle.rxpermissions.RxPermissions;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 @SuppressWarnings({"ConstantConditions", "CodeBlock2Expr"})
 public class AppActivity extends AppCompatActivity implements MediaPicker.Provider {
@@ -119,5 +123,20 @@ public class AppActivity extends AppCompatActivity implements MediaPicker.Provid
     @Override
     public Context getContext() {
         return this;
+    }
+
+    @Override
+    public File getImageFile() {
+        final File imagesDirectory = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES), "Pictures");
+
+        if (!imagesDirectory.mkdirs() && !imagesDirectory.isDirectory()) {
+            Log.e("MediaPicker", "Directory not created");
+        }
+
+        @SuppressLint("SimpleDateFormat")
+        final String timeStamp = (new SimpleDateFormat("yyyyMMdd_HHmmss")).format(new Date());
+        final String imageFileName = timeStamp + ".jpg";
+
+        return new File(imagesDirectory, "imageFile-" + imageFileName);
     }
 }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,3 @@
+<paths>
+    <external-path name="pictures" path="Pictures" />
+</paths>

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 
 POM_GROUP_ID=com.miguelgaeta.android-media-picker
 POM_ARTIFACT_ID=media-picker
-POM_VERSION_ID=1.5.0
+POM_VERSION_ID=1.5.1

--- a/media-picker/build.gradle
+++ b/media-picker/build.gradle
@@ -28,3 +28,5 @@ dependencies {
     //noinspection GradleDynamicVersion || File cropping utility.
     compile 'me.villani.lorenzo.android:android-cropimage:1.+'
 }
+
+apply from: '../build.release-aar.gradle'

--- a/media-picker/build.gradle
+++ b/media-picker/build.gradle
@@ -28,5 +28,3 @@ dependencies {
     //noinspection GradleDynamicVersion || File cropping utility.
     compile 'me.villani.lorenzo.android:android-cropimage:1.+'
 }
-
-apply from: '../build.release-aar.gradle'

--- a/media-picker/src/main/AndroidManifest.xml
+++ b/media-picker/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <!-- Used for creating new files from camera -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application>
 

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
@@ -12,7 +12,6 @@ import android.os.Build;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.v4.content.FileProvider;
-import android.util.Log;
 
 import com.android.camera.CropImageIntentBuilder;
 
@@ -315,8 +314,6 @@ public class MediaPicker {
         final Context context = provider.getContext();
 
         final String authority = context.getPackageName() + ".file-provider";
-
-        Log.e("MediaPicker", "Auth: " + authority);
 
         final Uri captureFileURI = FileProvider.getUriForFile(context, authority, file);
 

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
@@ -273,7 +273,7 @@ public class MediaPicker {
             case CAMERA:
             case CROP:
 
-                return getCaptureFileUri(context);
+                return getCaptureFileUriAndClear(context);
 
             case CHOOSER:
 
@@ -282,7 +282,7 @@ public class MediaPicker {
                     return data.getData();
                 }
 
-                return getCaptureFileUri(context);
+                return getCaptureFileUriAndClear(context);
 
             case DOCUMENTS:
             case GALLERY:
@@ -346,7 +346,7 @@ public class MediaPicker {
      *
      * @return Associated file Uri if found.
      */
-    private static Uri getCaptureFileUri(final Context context) {
+    private static Uri getCaptureFileUriAndClear(final Context context) {
 
         final String uriString = getSharedPreferences(context).getString("picker_uri", null);
 

--- a/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
+++ b/media-picker/src/main/java/com/miguelgaeta/media_picker/MediaPicker.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.v4.content.FileProvider;
+import android.util.Log;
 
 import com.android.camera.CropImageIntentBuilder;
 
@@ -239,8 +240,6 @@ public class MediaPicker {
 
                 case Activity.RESULT_CANCELED:
 
-                    deleteCaptureFileUri(context);
-
                     onError.onCancelled();
 
                     break;
@@ -275,23 +274,19 @@ public class MediaPicker {
             case CAMERA:
             case CROP:
 
-                return getCaptureFileUriAndClear(context);
+                return getCaptureFileUri(context);
 
             case CHOOSER:
 
                 if (data != null && data.getData() != null) {
 
-                    deleteCaptureFileUri(context);
-
                     return data.getData();
                 }
 
-                return getCaptureFileUriAndClear(context);
+                return getCaptureFileUri(context);
 
             case DOCUMENTS:
             case GALLERY:
-
-                deleteCaptureFileUri(context);
 
                 if (data == null || data.getData() == null) {
 
@@ -320,6 +315,8 @@ public class MediaPicker {
         final Context context = provider.getContext();
 
         final String authority = context.getPackageName() + ".file-provider";
+
+        Log.e("MediaPicker", "Auth: " + authority);
 
         final Uri captureFileURI = FileProvider.getUriForFile(context, authority, file);
 
@@ -352,7 +349,7 @@ public class MediaPicker {
      *
      * @return Associated file Uri if found.
      */
-    private static Uri getCaptureFileUriAndClear(final Context context) {
+    private static Uri getCaptureFileUri(final Context context) {
 
         final String uriString = getSharedPreferences(context).getString("picker_uri", null);
 
@@ -375,28 +372,6 @@ public class MediaPicker {
      */
     private static SharedPreferences getSharedPreferences(final Context context) {
         return context.getSharedPreferences("picker", Context.MODE_PRIVATE);
-    }
-
-    /**
-     * If present, delete capture file URI from disk.
-     *
-     * @return Returns true if cleaned successfully.
-     */
-    private static boolean deleteCaptureFileUri(final Context context) throws IOException {
-
-        final Uri uri = getCaptureFileUriAndClear(context);
-
-        if (uri != null) {
-
-            final File file = MediaPickerUri.resolveToFile(context, uri);
-            final boolean result = file.delete();
-
-            refreshSystemMediaScanDataBase(context, file);
-
-            return result;
-        }
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
Fixes a bug where since files created for the camera no longer need to be physically created, the code to clean them up if no longer required.

Updated the sample application to create it's own temporary files and use `FileProvider` API.

I feel like the setup is not non-trivial so I've made an issue to update the `README.md` to include a more detailed explanation on the nuances of `FileProvider`.