### PR TITLE
Replace android-cropimage with uCrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 
 ### Configuration
 
-This library provides image cropping functionality via a dependency to Lorenzo Villani's [Crop Image](https://github.com/lvillani/android-cropimage).  When including this library add his repository to your `build.gradle` to obtain the dependency.
+This library provides image cropping functionality via a dependency to Yalantis's [uCrop](https://github.com/Yalantis/uCrop).  When including this library add the following to your `build.gradle` to obtain the dependency.
 
 ```groovy
 
@@ -86,10 +86,7 @@ allprojects {
 
     repositories {
         jcenter()
-
-        maven {
-            url 'http://lorenzo.villani.me/android-cropimage/'
-        }
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'com.android.application'
 //noinspection GroovyMissingReturnStatement
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    buildToolsVersion '25.0.3'
 
     defaultConfig {
         applicationId "com.miguelgaeta.android_media_picker"
@@ -34,12 +34,17 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    repositories {
+        jcenter()
+        maven { url 'https://jitpack.io' }
+    }
 }
 
 dependencies {
 
     // Support libraries.
-    compile 'com.android.support:appcompat-v7:25.2.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
 
     // Rx Java permissions handler.
     compile 'com.tbruyelle.rxpermissions:rxpermissions:0.5.2@aar'

--- a/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
+++ b/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
@@ -87,7 +87,6 @@ public class AppActivity extends AppCompatActivity implements MediaPicker.Provid
 
                 if (request != RequestType.CROP && MimeType.isImage(mimeType)) {
 
-//                    final int paramColor = ContextCompat.getColor(AppActivity.this, android.R.color.black);
                     final int paramWidth = 512;
                     final int paramHeight = 512;
 

--- a/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
+++ b/app/src/main/java/com/miguelgaeta/android_media_picker/AppActivity.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.widget.ImageView;
@@ -88,11 +87,11 @@ public class AppActivity extends AppCompatActivity implements MediaPicker.Provid
 
                 if (request != RequestType.CROP && MimeType.isImage(mimeType)) {
 
-                    final int paramColor = ContextCompat.getColor(AppActivity.this, android.R.color.black);
+//                    final int paramColor = ContextCompat.getColor(AppActivity.this, android.R.color.black);
                     final int paramWidth = 512;
                     final int paramHeight = 512;
 
-                    MediaPicker.startForImageCrop(AppActivity.this, uri, paramWidth, paramHeight, paramColor, e -> {
+                    MediaPicker.startForImageCrop(AppActivity.this, uri, paramWidth, paramHeight, e -> {
 
                         Log.e("MediaPicker", "Open cropper error.", e);
                     });

--- a/media-picker/build.gradle
+++ b/media-picker/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 
     // File cropping utility.
     compile 'com.github.yalantis:ucrop:2.2.1'
-    compile 'com.github.yalantis:ucrop:2.2.1-native'
 }
 
 apply from: '../build.release-aar.gradle'

--- a/media-picker/build.gradle
+++ b/media-picker/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 //noinspection GroovyMissingReturnStatement
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    buildToolsVersion '25.0.3'
 
     defaultConfig {
         minSdkVersion 15
@@ -18,15 +18,21 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    repositories {
+        jcenter()
+        maven { url 'https://jitpack.io' }
+    }
 }
 
 dependencies {
 
-    //noinspection GradleDynamicVersion || File provider compatibility.
-    compile 'com.android.support:support-core-utils:25.+'
+    // File provider compatibility.
+    compile 'com.android.support:support-core-utils:25.3.1'
 
-    //noinspection GradleDynamicVersion || File cropping utility.
-    compile 'me.villani.lorenzo.android:android-cropimage:1.+'
+    // File cropping utility.
+    compile 'com.github.yalantis:ucrop:2.2.1'
+    compile 'com.github.yalantis:ucrop:2.2.1-native'
 }
 
 apply from: '../build.release-aar.gradle'

--- a/media-picker/src/main/AndroidManifest.xml
+++ b/media-picker/src/main/AndroidManifest.xml
@@ -12,7 +12,9 @@
     <application>
 
         <!-- Used for cropping images -->
-        <activity android:name="com.android.camera.CropImage"/>
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
 
     </application>
 


### PR DESCRIPTION
Replaces [android-cropimage](https://github.com/lvillani/android-cropimage) with [uCrop](https://github.com/Yalantis/uCrop) as the cropping solution. This does provide several additional cropping features such as rotation and aspect ratio changes.

Also bumps various build tool versions.

- [ ] Release a beta and test on various devices
- [ ] Verify that we can theme the activity in a client of this library