### PR TITLE
[Android] Bumps uCrop to 2.2.3 and includes the native library.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext._targetSdkVersion = 28
     ext._minSdkVersion = 16
 
-    ext.ucropVersion = '2.2.2'
+    ext.ucropVersion = '2.2.3'
 
     repositories {
         jcenter()

--- a/media-picker/build.gradle
+++ b/media-picker/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
     // File cropping utility.
     implementation "com.github.yalantis:ucrop:$ucropVersion"
+    implementation "com.github.yalantis:ucrop:$ucropVersion-native"
 }
 
 apply from: '../build.release-aar.gradle'


### PR DESCRIPTION
Bumps uCrop (https://github.com/Yalantis/uCrop) to 2.2.3 and includes the native library, which supposedly helps preserve image quality.